### PR TITLE
Merge upstream to fix warnings in newer CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.2...3.27)
 project(cmake_git_version_tracking
     LANGUAGES C)
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The core capability is baked into single self-contained
 ## Quickstart via FetchContent
 You can use CMake's `FetchContent` module to build the static library `cmake_git_version_tracking`:
 ```cmake
+include(FetchContent)
 FetchContent_Declare(cmake_git_version_tracking                   
   GIT_REPOSITORY https://github.com/andrew-hardin/cmake-git-version-tracking.git
   GIT_TAG 904dbda1336ba4b9a1415a68d5f203f576b696bb


### PR DESCRIPTION
Update required to deal with the same issue the upstream are fixing: warning from newer CMake about supported CMake version declaration.